### PR TITLE
Update RecordAudio page to use CreateRecord

### DIFF
--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -34,6 +34,7 @@ class RecordAudio extends CreateRecord
                     ->native()
                     ->options([])
                     ->required(),
+                
                 Toggle::make('redact_pii')
                     ->default(true)
                     ->label('Redact Personally Identifiable Information'),
@@ -41,7 +42,7 @@ class RecordAudio extends CreateRecord
             ->statePath('data');
     }
 
-    public function create(): void
+    public function create(bool $another = false): void
     {
         if (! $this->recording) {
             return;


### PR DESCRIPTION
## Summary
- rework RecordAudio so it extends `CreateRecord`
- attach recorded audio to a new Transcript and redirect to its edit page

## Testing
- `composer test` *(fails: `vendor/bin/pest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68726368fe1c83339b9367444969d777