### PR TITLE
Fix resetting audio chunks

### DIFF
--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -46,6 +46,7 @@
             }
         },
         start() {
+            this.chunks = [];
             navigator.mediaDevices.getUserMedia({
                 audio: { deviceId: this.selectedDevice ? { exact: this.selectedDevice } : undefined }
             }).then(stream => {
@@ -97,6 +98,7 @@
             const blob = new Blob(this.chunks, { type: 'audio/webm;codecs=opus' });
             const file = new File([blob], `recording-${Date.now()}.webm`, { type: blob.type });
             this.$wire.upload('recording', file, () => this.$wire.create(), () => {}, (e) => console.error(e));
+            this.chunks = [];
         }
     }"
     x-init="init()"


### PR DESCRIPTION
## Summary
- clear chunks before starting a new recording
- clear chunks after upload to avoid reusing stale data

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727d2d6d7c8333b683a324c6389f75