### PR TITLE
Improve recorder error handling

### DIFF
--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -15,6 +15,7 @@
         timerInterval: null,
         keepAlive: null,
         selectEl: null,
+        statusMessage: '',
         init() {
             // Locate the select element rendered by the Filament form.
             // Using a generic query avoids coupling to the name attribute
@@ -46,6 +47,7 @@
             }
         },
         start() {
+            this.statusMessage = '';
             navigator.mediaDevices.getUserMedia({
                 audio: { deviceId: this.selectedDevice ? { exact: this.selectedDevice } : undefined }
             }).then(stream => {
@@ -62,12 +64,19 @@
                     this.devices = list.filter(d => d.kind === 'audioinput');
                     this.populateSelect();
                 });
-                this.keepAlive = setInterval(() => {
-                    fetch(this.pingUrl, {
-                        headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                        credentials: 'same-origin'
-                    });
+                this.keepAlive = setInterval(async () => {
+                    try {
+                        await fetch(this.pingUrl, {
+                            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                            credentials: 'same-origin'
+                        });
+                    } catch (error) {
+                        console.error('Ping failed', error);
+                    }
                 }, 60000);
+            }).catch(error => {
+                console.error('Error accessing microphone', error);
+                this.statusMessage = 'Unable to access microphone';
             });
         },
         stop() {
@@ -111,4 +120,5 @@
         <x-filament::button type="button" x-show="!recording" @click="start()">Start</x-filament::button>
         <x-filament::button type="button" x-show="recording" @click="stop()">Stop</x-filament::button>
     </div>
+    <p x-show="statusMessage" x-text="statusMessage" class="text-danger-600"></p>
 </div>


### PR DESCRIPTION
## Summary
- handle getUserMedia failures with a catch block
- log keep-alive ping failures
- show a simple status message in the component

## Testing
- `composer test` *(fails: vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68727d5273b08333a6f1e06feade5c7a