### PR TITLE
Add local download of recorded audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ QUEUE_CONNECTION=database
 ```
 
 
+When recording audio through the provided recorder, the browser will also save a `recording-<timestamp>.webm` file locally before uploading. This ensures you retain a copy if the upload fails.
+
+
 ## Usage
 
 ```php

--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -93,8 +93,20 @@
             }, 1000);
         },
         stopTimer() { clearInterval(this.timerInterval); },
+        downloadRecording(blob) {
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.style.display = 'none';
+            link.href = url;
+            link.download = `recording-${Date.now()}.webm`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+        },
         upload() {
             const blob = new Blob(this.chunks, { type: 'audio/webm;codecs=opus' });
+            this.downloadRecording(blob);
             const file = new File([blob], `recording-${Date.now()}.webm`, { type: blob.type });
             this.$wire.upload('recording', file, () => this.$wire.create(), () => {}, (e) => console.error(e));
         }


### PR DESCRIPTION
## Summary
- let the recorder download a local copy before upload
- document fallback file in README

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727d64aec883339d31c58016c0d9db