### PR TITLE
Refactor sound check and recording components

### DIFF
--- a/resources/lang/en/audio_recorder.php
+++ b/resources/lang/en/audio_recorder.php
@@ -1,0 +1,17 @@
+<?php
+return [
+    'sound_check' => [
+        'title' => 'Sound Check',
+        'note' => 'Make sure when speaking the volume level is reaching at least 50%',
+    ],
+    'recording_session' => [
+        'title' => 'Recording Session in Progress',
+        'note_save' => 'When recording is finished a copy will be saved directly to your downloads folder.',
+        'note_upload' => 'A copy will also be immediately uploaded for transcription.',
+    ],
+    'buttons' => [
+        'check_levels' => 'Step 1 - Check Levels',
+        'start_recording' => 'Start Recording',
+        'stop' => 'Stop',
+    ],
+];

--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -197,21 +197,6 @@
     >
         {{ $this->form }}
 
-        <div x-show="checkingLevels" class="text-center">
-            <h2 class=" fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">Sound Check</h2>
-            <p class="mb-4">Make sure when speaking the volume level is reaching at least 50%</p>
-        </div>
-
-        <div x-show="recording"  class="text-center">
-            <h2 class="fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">Recording Session in Progress</h2>
-            <p>When recording is finished a copy will be saved directly to your downloads folder.</p>
-            <p class="mb-4">A copy will also be immediately uploaded for transcription.</p>
-            <p class="flex items-center justify-center space-x-2">
-                <span class="text-danger-600 animate-pulse me-1">&#9679;</span>
-                <span x-text="timer" class="text-3xl"></span>
-            </p>
-        </div>
-
 
         <div x-show="recording || checkingLevels" class="flex justify-center space-x-0.5 mb-4">
             <template x-for="i in totalSegments" :key="i">
@@ -225,10 +210,16 @@
             </template>
         </div>
         <div class="flex space-x-2 justify-center">
-            <x-filament::button type="button" x-show="!recording && !checkingLevels" @click="startLevelCheck()">Step 1 - Check Levels</x-filament::button>
+            <x-filament::button type="button" x-show="!recording && !checkingLevels" @click="startLevelCheck()">
+                {{ __('vb-transcribe::audio_recorder.buttons.check_levels') }}
+            </x-filament::button>
             {{--        <x-filament::button type="button" x-show="checkingLevels" @click="stopLevelCheck()">Stop Check</x-filament::button>--}}
-            <x-filament::button type="button" icon="heroicon-m-microphone" x-show="checkingLevels" @click="start()">Start Recording</x-filament::button>
-            <x-filament::button type="button" x-show="recording" @click="stop()">Stop</x-filament::button>
+            <x-filament::button type="button" icon="heroicon-m-microphone" x-show="checkingLevels" @click="start()">
+                {{ __('vb-transcribe::audio_recorder.buttons.start_recording') }}
+            </x-filament::button>
+            <x-filament::button type="button" x-show="recording" @click="stop()">
+                {{ __('vb-transcribe::audio_recorder.buttons.stop') }}
+            </x-filament::button>
         </div>
         <p x-show="statusMessage" x-text="statusMessage" class="text-danger-600"></p>
     </div>

--- a/resources/views/components/recording_info.blade.php
+++ b/resources/views/components/recording_info.blade.php
@@ -1,0 +1,11 @@
+<div x-show="recording" class="text-center">
+    <h2 class="fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+        {{ __('vb-transcribe::audio_recorder.recording_session.title') }}
+    </h2>
+    <p>{{ __('vb-transcribe::audio_recorder.recording_session.note_save') }}</p>
+    <p class="mb-4">{{ __('vb-transcribe::audio_recorder.recording_session.note_upload') }}</p>
+    <p class="flex items-center justify-center space-x-2">
+        <span class="text-danger-600 animate-pulse me-1">&#9679;</span>
+        <span x-text="timer" class="text-3xl"></span>
+    </p>
+</div>

--- a/resources/views/components/sound_check.blade.php
+++ b/resources/views/components/sound_check.blade.php
@@ -1,0 +1,6 @@
+<div x-show="checkingLevels" class="text-center">
+    <h2 class="fi-header-heading text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+        {{ __('vb-transcribe::audio_recorder.sound_check.title') }}
+    </h2>
+    <p class="mb-4">{{ __('vb-transcribe::audio_recorder.sound_check.note') }}</p>
+</div>

--- a/src/Filament/Forms/Components/RecordingInfo.php
+++ b/src/Filament/Forms/Components/RecordingInfo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
+
+use Filament\Forms\Components\Component;
+
+class RecordingInfo extends Component
+{
+    protected string $view = 'filament-transcribe::components.recording_info';
+
+    public static function make(string $name = 'recordingInfo'): static
+    {
+        return app(static::class);
+    }
+}

--- a/src/Filament/Forms/Components/SoundCheck.php
+++ b/src/Filament/Forms/Components/SoundCheck.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
+
+use Filament\Forms\Components\Component;
+
+class SoundCheck extends Component
+{
+    protected string $view = 'filament-transcribe::components.sound_check';
+
+    public static function make(string $name = 'soundCheck'): static
+    {
+        return app(static::class);
+    }
+}

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -9,6 +9,8 @@ use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Storage;
 use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Livewire\WithFileUploads;
+use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
+use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\SoundCheck;
 
 class RecordAudio extends CreateRecord
 {
@@ -33,11 +35,16 @@ class RecordAudio extends CreateRecord
                     ->label('Audio Source')
                     ->native()
                     ->options([])
-                    ->required(),
-                
+                    ->required()
+                    ->extraAttributes(['x-show' => '!recording && !checkingLevels']),
+
                 Toggle::make('redact_pii')
                     ->default(true)
-                    ->label('Redact Personally Identifiable Information'),
+                    ->label('Redact Personally Identifiable Information')
+                    ->extraAttributes(['x-show' => '!recording && !checkingLevels']),
+
+                SoundCheck::make(),
+                RecordingInfo::make(),
             ])
             ->statePath('data');
     }


### PR DESCRIPTION
## Summary
- translate audio recorder help notes
- create `SoundCheck` and `RecordingInfo` components
- use these components in the RecordAudio form
- hide source selector and PII toggle while recording

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d65544108333bb0288a2d3ab657c