### PR TITLE
Fix entangle usage

### DIFF
--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -89,4 +89,26 @@ class RecordAudio extends CreateRecord
 
         $this->redirect(TranscriptResource::getUrl('edit', ['record' => $transcript]));
     }
+
+    public function startLevelCheck(): void
+    {
+        $this->checkingLevels = true;
+    }
+
+    public function stopLevelCheck(): void
+    {
+        $this->checkingLevels = false;
+    }
+
+    public function startRecording(): void
+    {
+        $this->recording = true;
+        $this->checkingLevels = false;
+    }
+
+    public function stopRecording(): void
+    {
+        $this->recording = false;
+        $this->checkingLevels = false;
+    }
 }


### PR DESCRIPTION
## Summary
- correct `$wire` entanglement syntax for `recording` and `checkingLevels`
- use `.live` so Livewire receives changes immediately


------
https://chatgpt.com/codex/tasks/task_e_6872e4a129488333968c61aa73622a2d