### PR TITLE
Improve timer and UI controls

### DIFF
--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -22,6 +22,7 @@
         meterRAF: null,
         timer: '00:00:00',
         seconds: 0,
+        startTime: null,
         timerInterval: null,
         keepAlive: null,
         selectEl: null,
@@ -123,16 +124,23 @@
             this.stopVuMeter();
         },
         startTimer() {
+            this.startTime = Date.now();
             this.seconds = 0;
+            clearInterval(this.timerInterval);
             this.timerInterval = setInterval(() => {
-                this.seconds++;
-                const h = String(Math.floor(this.seconds / 3600)).padStart(2, '0');
-                const m = String(Math.floor((this.seconds % 3600) / 60)).padStart(2, '0');
-                const s = String(this.seconds % 60).padStart(2, '0');
+                const diff = Math.floor((Date.now() - this.startTime) / 1000);
+                this.seconds = diff;
+                const h = String(Math.floor(diff / 3600)).padStart(2, '0');
+                const m = String(Math.floor((diff % 3600) / 60)).padStart(2, '0');
+                const s = String(diff % 60).padStart(2, '0');
                 this.timer = `${h}:${m}:${s}`;
             }, 1000);
         },
-        stopTimer() { clearInterval(this.timerInterval); },
+        stopTimer() {
+            clearInterval(this.timerInterval);
+            this.timerInterval = null;
+            this.startTime = null;
+        },
         downloadRecording(blob) {
             const url = URL.createObjectURL(blob);
             const link = document.createElement('a');
@@ -194,18 +202,7 @@
 
 
 
-        <div class="flex space-x-2 justify-center">
-            <x-filament::button type="button" x-show="!recording && !checkingLevels && !showProgress" @click="$wire.startLevelCheck()">
-                {{ __('vb-transcribe::audio_recorder.buttons.check_levels') }}
-            </x-filament::button>
-            {{--        <x-filament::button type="button" x-show="checkingLevels" @click="stopLevelCheck()">Stop Check</x-filament::button>--}}
-            <x-filament::button type="button" icon="heroicon-m-microphone" x-show="checkingLevels" @click="$wire.startRecording()">
-                {{ __('vb-transcribe::audio_recorder.buttons.start_recording') }}
-            </x-filament::button>
-            <x-filament::button type="button" x-show="recording" @click="$wire.stopRecording()">
-                {{ __('vb-transcribe::audio_recorder.buttons.stop') }}
-            </x-filament::button>
-        </div>
+
         <p x-show="statusMessage" x-text="statusMessage" class="text-danger-600"></p>
     </div>
 </div>

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -6,6 +6,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Form;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Storage;
@@ -72,6 +73,21 @@ class RecordAudio extends CreateRecord
                             ->label(false)
                             ->content(new HtmlString("<div class='flex items-center justify-center min-h-[100px]'><div class='block-loader'></div><span class='ml-4'>Uploading your audio file</span></div>"))
                             ->visible(fn($livewire) => $livewire->showProgress),
+                    ])
+                    ->footerActions([
+                        Action::make('check_levels')
+                            ->label(__('vb-transcribe::audio_recorder.buttons.check_levels'))
+                            ->visible(fn($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress)
+                            ->action('startLevelCheck'),
+                        Action::make('start_recording')
+                            ->icon('heroicon-m-microphone')
+                            ->label(__('vb-transcribe::audio_recorder.buttons.start_recording'))
+                            ->visible(fn($livewire) => $livewire->checkingLevels)
+                            ->action('startRecording'),
+                        Action::make('stop_recording')
+                            ->label(__('vb-transcribe::audio_recorder.buttons.stop'))
+                            ->visible(fn($livewire) => $livewire->recording)
+                            ->action('stopRecording'),
                     ])
             ])
             ->statePath('data');


### PR DESCRIPTION
## Summary
- make the recording timer use actual elapsed time
- place recorder controls inside `Section` footer actions

## Testing
- `php -l src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php`
- `php -l resources/views/components/audio_recorder.blade.php`
- `composer format` *(fails: `vendor/bin/pint` not found)*
- `composer test` *(fails: `vendor/bin/pest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730dc4272083338ee493bb4d50d4c0