### PR TITLE
Add upload progress display

### DIFF
--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -19,6 +19,7 @@
         vuSensitivity: 4,
         checkingLevels: $wire.entangle('checkingLevels'),
         showProgress: $wire.entangle('showProgress'),
+        uploadProgress: 0,
         meterRAF: null,
         timer: '00:00:00',
         seconds: 0,
@@ -156,7 +157,15 @@
             const blob = new Blob(this.chunks, { type: 'audio/webm;codecs=opus' });
             this.downloadRecording(blob);
             const file = new File([blob], `recording-${Date.now()}.webm`, { type: blob.type });
-            this.$wire.upload('recordingFile', file, () => this.$wire.create(), () => {}, (e) => console.error(e));
+            this.uploadProgress = 0;
+            this.$wire.upload(
+                'recordingFile',
+                file,
+                () => this.$wire.create(),
+                () => {},
+                (e) => { this.uploadProgress = e.detail.progress; },
+                () => {}
+            );
             this.chunks = [];
         },
         initVuMeter(stream) {

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -70,7 +70,13 @@ class RecordAudio extends CreateRecord
                         RecordingInfo::make(),
                         Placeholder::make('progress')
                             ->label(false)
-                            ->content(new HtmlString("<div class='flex items-center justify-center min-h-[100px]'><div class='block-loader'></div><span class='ml-4'>Uploading your audio file</span></div>"))
+                            ->content(new HtmlString(
+                                "<div class='flex flex-col items-center justify-center min-h-[100px] space-y-2'>"
+                                ."<div class='block-loader'></div>"
+                                ."<progress max='100' class='w-full' x-bind:value=\"uploadProgress\"></progress>"
+                                ."<span>Uploading your audio file</span>"
+                                ."</div>"
+                            ))
                             ->visible(fn($livewire) => $livewire->showProgress),
                     ])
                     ->footerActions([


### PR DESCRIPTION
## Summary
- update audio recorder JS to track upload progress
- show upload progress bar during file transfer

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer format` *(fails: vendor/bin/pint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68738bf8dd608333a6a50801f9b82864