### PR TITLE
Add upload progress display

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -36,3 +36,8 @@
 .vu-meter-bar.vu-green { background-color: #16a34a; }
 .vu-meter-bar.vu-amber { background-color: #d97706; }
 .vu-meter-bar.vu-red { background-color: #b91c1c; }
+
+/* Upload progress bar */
+.upload-progress-bar {
+    background-color: #14b8a6; /* teal-500 */
+}

--- a/resources/views/components/audio_recorder.blade.php
+++ b/resources/views/components/audio_recorder.blade.php
@@ -19,6 +19,9 @@
         vuSensitivity: 4,
         checkingLevels: $wire.entangle('checkingLevels'),
         showProgress: $wire.entangle('showProgress'),
+        uploadProgress: 0,
+        uploadFileName: '',
+        uploadFileSize: '',
         meterRAF: null,
         timer: '00:00:00',
         seconds: 0,
@@ -156,7 +159,20 @@
             const blob = new Blob(this.chunks, { type: 'audio/webm;codecs=opus' });
             this.downloadRecording(blob);
             const file = new File([blob], `recording-${Date.now()}.webm`, { type: blob.type });
-            this.$wire.upload('recordingFile', file, () => this.$wire.create(), () => {}, (e) => console.error(e));
+            this.uploadProgress = 0;
+            this.uploadFileName = file.name;
+            const sizeKb = file.size / 1024;
+            this.uploadFileSize = sizeKb > 1024
+                ? `${(sizeKb / 1024).toFixed(1)} MB`
+                : `${sizeKb.toFixed(1)} KB`;
+            this.$wire.upload(
+                'recordingFile',
+                file,
+                () => this.$wire.create(),
+                () => {},
+                (e) => { this.uploadProgress = e.detail.progress; },
+                () => {}
+            );
             this.chunks = [];
         },
         initVuMeter(stream) {

--- a/resources/views/components/upload_progress.blade.php
+++ b/resources/views/components/upload_progress.blade.php
@@ -1,0 +1,23 @@
+<div class="space-y-2">
+    <div class="flex justify-between items-center">
+        <div class="flex items-center gap-x-3">
+            <span class="size-8 flex justify-center items-center border border-gray-200 text-gray-500 rounded-lg dark:border-neutral-700 dark:text-neutral-500">
+                <svg class="shrink-0 size-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12-9H3v18h18V3z" />
+                </svg>
+            </span>
+            <div>
+                <p class="text-sm font-medium text-gray-800 dark:text-white" x-text="uploadFileName"></p>
+                <p class="text-xs text-gray-500 dark:text-neutral-500" x-text="uploadFileSize"></p>
+            </div>
+        </div>
+    </div>
+    <div class="flex items-center gap-x-3 whitespace-nowrap">
+        <div class="flex w-full h-2 bg-gray-200 rounded-full overflow-hidden dark:bg-neutral-700">
+            <div class="flex flex-col justify-center rounded-full overflow-hidden upload-progress-bar text-xs text-white text-center whitespace-nowrap transition duration-500" x-bind:style="`width: ${uploadProgress}%`"></div>
+        </div>
+        <div class="w-6 text-end">
+            <span class="text-sm text-gray-800 dark:text-white" x-text="`${uploadProgress}%`"></span>
+        </div>
+    </div>
+</div>

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -15,7 +15,6 @@ use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Livewire\WithFileUploads;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\SoundCheck;
-use Illuminate\Support\HtmlString;
 
 class RecordAudio extends CreateRecord
 {
@@ -70,7 +69,7 @@ class RecordAudio extends CreateRecord
                         RecordingInfo::make(),
                         Placeholder::make('progress')
                             ->label(false)
-                            ->content(new HtmlString("<div class='flex items-center justify-center min-h-[100px]'><div class='block-loader'></div><span class='ml-4'>Uploading your audio file</span></div>"))
+                            ->content(fn() => view('filament-transcribe::components.upload_progress'))
                             ->visible(fn($livewire) => $livewire->showProgress),
                     ])
                     ->footerActions([


### PR DESCRIPTION
## Summary
- update audio recorder JS to capture filename and size
- show progress bar with filename and size while uploading
- move upload progress placeholder to Blade view
- style upload progress bar so color is visible

## Testing
- `composer test`
- `composer install`
- `composer format`


------
https://chatgpt.com/codex/tasks/task_e_68738bf8dd608333a6a50801f9b82864