### PR TITLE
Fix dependency constraints for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0"
+        "pestphp/pest": "^2.0 || ^3.0",
+        "pestphp/pest-plugin-arch": "^2.0 || ^3.0",
+        "pestphp/pest-plugin-laravel": "^2.4 || ^3.0"
     },
     "suggest": {
         "pusher/pusher-php-server": "Recommended if you wish to broadcast events using Pusher."


### PR DESCRIPTION
## Summary
- allow Pest 2.x and 3.x
- allow matching pest plugins to support Laravel 10 in CI

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687403f0cae48333a90fa843bed41c93