### PR TITLE
Fix CSS asset URL uses HTTPS

### DIFF
--- a/src/FilamentTranscribeServiceProvider.php
+++ b/src/FilamentTranscribeServiceProvider.php
@@ -41,7 +41,7 @@ class FilamentTranscribeServiceProvider extends PackageServiceProvider
         $publishedPath = public_path('vendor/filament-transcribe/filament-transcribe.css');
 
         $cssPath = file_exists($publishedPath)
-            ? asset('vendor/filament-transcribe/filament-transcribe.css')
+            ? secure_asset('vendor/filament-transcribe/filament-transcribe.css')
             : __DIR__ . '/../resources/css/style.css';
 
         FilamentAsset::register([


### PR DESCRIPTION
## Summary
- load Filament Transcribe styles via `secure_asset()`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687414a481a083338dff91b8b4bf1706