### PR TITLE
Fix Livewire dispatch for transcript update

### DIFF
--- a/resources/views/components/transcript_echo.blade.php
+++ b/resources/views/components/transcript_echo.blade.php
@@ -7,7 +7,7 @@
             window.Echo.private('transcript.' + @js($transcriptId))
                 .listen('.transcript.updated', (event) => {
                     console.log('Transcript updated event received')
-                    setTimeout(() => $wire.dispatch('transcriptUpdated', {transcript: event.transcript}), 300);
+                    setTimeout(() => Livewire.dispatch('transcriptUpdated', {transcript: event.transcript}), 300);
                 })
         });
     "


### PR DESCRIPTION
## Summary
- use `Livewire.dispatch` when notifying Livewire that transcription has finished

## Testing
- `composer install --no-interaction`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68743dd324a88333ac4ca5596f8a70dd