### PR TITLE
Simplify recording storage

### DIFF
--- a/src/Filament/Resources/TranscriptResource/Pages/CreateTranscript.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/CreateTranscript.php
@@ -2,22 +2,14 @@
 
 namespace App\Filament\Resources\TranscriptResource\Pages;
 
-use Filament\Actions\Action;
 use Filament\Resources\Pages\CreateRecord;
 use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
-use Visualbuilder\FilamentTranscribe\Jobs\TranscribeAudioJob;
 
 class CreateTranscript extends CreateRecord
 {
     protected static string $resource = TranscriptResource::class;
 
-    protected function getCreateFormAction(): Action
-    {
-        return Action::make('create')
-            ->label(__('filament-panels::resources/pages/create-record.form.actions.create.label'))
-            ->submit('create')
-            ->keyBindings(['mod+s']);
-    }
+    // Default create action is sufficient as audio is submitted via AudioUploadField
 
 
 }

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -10,7 +10,6 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Form;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Support\Enums\Alignment;
-use Illuminate\Support\Facades\Storage;
 use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Livewire\WithFileUploads;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
@@ -98,24 +97,20 @@ class RecordAudio extends CreateRecord
             return;
         }
 
-        $disk = config('filament-transcribe.recordings.disk');
-        $dir  = trim(config('filament-transcribe.recordings.directory'), '/');
         $name = 'recording-' . now()->format('YmdHis') . '.webm';
-        $path = $this->recordingFile->storeAs($dir, $name, $disk);
-        $this->recordingFile = null;
-        $this->recording = false;
-        $this->checkingLevels = false;
 
         $model = TranscriptResource::getModel();
         $transcript = $model::create([
             'redact_pii' => $this->data['redact_pii'] ?? true,
         ]);
 
-        $transcript->addMedia(Storage::disk($disk)->path($path))
+        $transcript->addMedia($this->recordingFile->getRealPath())
             ->usingFileName($name)
             ->toMediaCollection('audio');
 
-        Storage::disk($disk)->delete($path);
+        $this->recordingFile = null;
+        $this->recording = false;
+        $this->checkingLevels = false;
 
         $this->redirect(TranscriptResource::getUrl('edit', ['record' => $transcript]));
     }


### PR DESCRIPTION
## Summary
- avoid temp disk when saving recorded audio
- default page action for transcript creation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687c476ef9108333ad0f6d95dcacef06