### PR TITLE
chore: capitalize VisualBuilder namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ When recording audio through the provided recorder, the browser will also save a
 ## Usage
 
 ```php
-$filamentTranscribe = new Visualbuilder\FilamentTranscribe();
-echo $filamentTranscribe->echoPhrase('Hello, Visualbuilder!');
+$filamentTranscribe = new VisualBuilder\FilamentTranscribe();
+echo $filamentTranscribe->echoPhrase('Hello, VisualBuilder!');
 ```
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,9 @@
     },
     "autoload": {
         "psr-4": {
-            "Visualbuilder\\FilamentTranscribe\\": "src/",
-            "Visualbuilder\\FilamentTranscribe\\Database\\Factories\\": "database/factories/",
-            "Visualbuilder\\FilamentTranscribe\\Database\\Migrations\\": "database/migrations/"
+            "VisualBuilder\\FilamentTranscribe\\": "src/",
+            "VisualBuilder\\FilamentTranscribe\\Database\\Factories\\": "database/factories/",
+            "VisualBuilder\\FilamentTranscribe\\Database\\Migrations\\": "database/migrations/"
         },
         "files": [
             "src/Support/Helpers.php"
@@ -48,7 +48,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Visualbuilder\\FilamentTranscribe\\Tests\\": "tests/",
+            "VisualBuilder\\FilamentTranscribe\\Tests\\": "tests/",
             "Workbench\\App\\": "workbench/app/"
         }
     },
@@ -70,10 +70,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Visualbuilder\\FilamentTranscribe\\FilamentTranscribeServiceProvider"
+                "VisualBuilder\\FilamentTranscribe\\FilamentTranscribeServiceProvider"
             ],
             "aliases": {
-                "FilamentTranscribe": "Visualbuilder\\FilamentTranscribe\\Facades\\FilamentTranscribe"
+                "FilamentTranscribe": "VisualBuilder\\FilamentTranscribe\\Facades\\FilamentTranscribe"
             }
         }
     },

--- a/config/filament-transcribe.php
+++ b/config/filament-transcribe.php
@@ -1,7 +1,7 @@
 <?php
 use Filament\Pages\SubNavigationPosition;
 
-// config for Visualbuilder/FilamentTranscribe
+// config for VisualBuilder/FilamentTranscribe
 return [
 
     /**
@@ -151,8 +151,8 @@ return [
         'subnav_position'   => SubNavigationPosition::Top
     ],
 
-    'transcript_model'    => \Visualbuilder\FilamentTranscribe\Models\Transcript::class,
-    'transcript_resource' => \Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource::class,
+    'transcript_model'    => \VisualBuilder\FilamentTranscribe\Models\Transcript::class,
+    'transcript_resource' => \VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource::class,
 
     /**
      * Which user classes will be available on the transcript owner morph select

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Database\Factories;
+namespace VisualBuilder\FilamentTranscribe\Database\Factories;
 
 /*
 class ModelFactory extends Factory

--- a/database/migrations/create_filament_transcribe_table.php.stub
+++ b/database/migrations/create_filament_transcribe_table.php.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
 
 return new class extends Migration
 {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="Visualbuilder Test Suite">
+        <testsuite name="VisualBuilder Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Commands;
+namespace VisualBuilder\FilamentTranscribe\Commands;
 
 use Illuminate\Console\Command;
 

--- a/src/Enums/EnumSubset.php
+++ b/src/Enums/EnumSubset.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Enums;
+namespace VisualBuilder\FilamentTranscribe\Enums;
 
 trait EnumSubset {
 

--- a/src/Enums/TranscriptStatus.php
+++ b/src/Enums/TranscriptStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Enums;
+namespace VisualBuilder\FilamentTranscribe\Enums;
 
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;

--- a/src/Events/TranscriptUpdated.php
+++ b/src/Events/TranscriptUpdated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Events;
+namespace VisualBuilder\FilamentTranscribe\Events;
 
 
 use Illuminate\Broadcasting\Channel;
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
 
 class TranscriptUpdated implements ShouldBroadcast
 {

--- a/src/Facades/FilamentTranscribe.php
+++ b/src/Facades/FilamentTranscribe.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Facades;
+namespace VisualBuilder\FilamentTranscribe\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Visualbuilder\FilamentTranscribe\FilamentTranscribe
+ * @see \VisualBuilder\FilamentTranscribe\FilamentTranscribe
  */
 class FilamentTranscribe extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return \Visualbuilder\FilamentTranscribe\FilamentTranscribe::class;
+        return \VisualBuilder\FilamentTranscribe\FilamentTranscribe::class;
     }
 }

--- a/src/Filament/Actions/StatusBadge.php
+++ b/src/Filament/Actions/StatusBadge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Actions;
+namespace VisualBuilder\FilamentTranscribe\Filament\Actions;
 
 use Filament\Forms\Components\Actions\Action;
 use Filament\Support\Enums\ActionSize;

--- a/src/Filament/Actions/TranscribeAction.php
+++ b/src/Filament/Actions/TranscribeAction.php
@@ -5,10 +5,10 @@ namespace VisualBuilder\FilamentTranscribe\Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Illuminate\Support\HtmlString;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages\EditTranscript;
-use Visualbuilder\FilamentTranscribe\Jobs\TranscribeAudioJob;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages\EditTranscript;
+use VisualBuilder\FilamentTranscribe\Jobs\TranscribeAudioJob;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
 
 class TranscribeAction extends Action
 {

--- a/src/Filament/Fields/AudioUploadField.php
+++ b/src/Filament/Fields/AudioUploadField.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Fields;
+namespace VisualBuilder\FilamentTranscribe\Filament\Fields;
 
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Illuminate\Support\HtmlString;

--- a/src/Filament/Fields/OwnerMorphSelectField.php
+++ b/src/Filament/Fields/OwnerMorphSelectField.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Fields;
+namespace VisualBuilder\FilamentTranscribe\Filament\Fields;
 
 use Filament\Forms\Components\MorphToSelect;
 use Filament\Forms\Get;

--- a/src/Filament/Forms/Components/AudioPlayer.php
+++ b/src/Filament/Forms/Components/AudioPlayer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
+namespace VisualBuilder\FilamentTranscribe\Filament\Forms\Components;
 
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\View;

--- a/src/Filament/Forms/Components/RecordingInfo.php
+++ b/src/Filament/Forms/Components/RecordingInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
+namespace VisualBuilder\FilamentTranscribe\Filament\Forms\Components;
 
 use Filament\Forms\Components\Component;
 

--- a/src/Filament/Forms/Components/SoundCheck.php
+++ b/src/Filament/Forms/Components/SoundCheck.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
+namespace VisualBuilder\FilamentTranscribe\Filament\Forms\Components;
 
 use Filament\Forms\Components\Component;
 

--- a/src/Filament/Resources/TranscriptResource.php
+++ b/src/Filament/Resources/TranscriptResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Resources;
+namespace VisualBuilder\FilamentTranscribe\Filament\Resources;
 
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Placeholder;
@@ -18,13 +18,13 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
 use Visualbuilder\FilamentTinyEditor\TinyEditor;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
-use Visualbuilder\FilamentTranscribe\Filament\Actions\StatusBadge;
-use Visualbuilder\FilamentTranscribe\Filament\Fields\AudioUploadField;
-use Visualbuilder\FilamentTranscribe\Filament\Fields\OwnerMorphSelectField;
-use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\AudioPlayer;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Filament\Actions\StatusBadge;
+use VisualBuilder\FilamentTranscribe\Filament\Fields\AudioUploadField;
+use VisualBuilder\FilamentTranscribe\Filament\Fields\OwnerMorphSelectField;
+use VisualBuilder\FilamentTranscribe\Filament\Forms\Components\AudioPlayer;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
 
 class TranscriptResource extends Resource
 {

--- a/src/Filament/Resources/TranscriptResource/Pages/CreateTranscript.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/CreateTranscript.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\TranscriptResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 
 class CreateTranscript extends CreateRecord
 {

--- a/src/Filament/Resources/TranscriptResource/Pages/EditTranscript.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/EditTranscript.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
+namespace VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
 
 
 use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Livewire\Attributes\On;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
 use VisualBuilder\FilamentTranscribe\Filament\Actions\TranscribeAction;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
-use Visualbuilder\FilamentTranscribe\Jobs\TranscribeAudioJob;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Jobs\TranscribeAudioJob;
 
 class EditTranscript extends EditRecord
 {

--- a/src/Filament/Resources/TranscriptResource/Pages/ListTranscripts.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/ListTranscripts.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
+namespace VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
 
 
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\MaxWidth;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
 
 class ListTranscripts extends ListRecords
 {

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
+namespace VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
 
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
@@ -11,10 +11,10 @@ use Filament\Forms\Form;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Support\Enums\Alignment;
 use Illuminate\Support\Facades\Storage;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Livewire\WithFileUploads;
-use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
-use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\SoundCheck;
+use VisualBuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
+use VisualBuilder\FilamentTranscribe\Filament\Forms\Components\SoundCheck;
 
 class RecordAudio extends CreateRecord
 {

--- a/src/FilamentTranscribe.php
+++ b/src/FilamentTranscribe.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe;
+namespace VisualBuilder\FilamentTranscribe;
 
 class FilamentTranscribe {}

--- a/src/FilamentTranscribePlugin.php
+++ b/src/FilamentTranscribePlugin.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe;
+namespace VisualBuilder\FilamentTranscribe;
 
 use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Pages\SubNavigationPosition;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 
 
 class FilamentTranscribePlugin implements Plugin

--- a/src/FilamentTranscribeServiceProvider.php
+++ b/src/FilamentTranscribeServiceProvider.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe;
+namespace VisualBuilder\FilamentTranscribe;
 
 use Filament\Support\Assets\Css;
 use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Visualbuilder\FilamentTranscribe\Commands\InstallCommand;
+use VisualBuilder\FilamentTranscribe\Commands\InstallCommand;
 
 class FilamentTranscribeServiceProvider extends PackageServiceProvider
 {

--- a/src/Jobs/PollTranscriptionJob.php
+++ b/src/Jobs/PollTranscriptionJob.php
@@ -1,5 +1,5 @@
 <?php
-namespace Visualbuilder\FilamentTranscribe\Jobs;
+namespace VisualBuilder\FilamentTranscribe\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -8,10 +8,10 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
-use Visualbuilder\FilamentTranscribe\Events\TranscriptUpdated;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
-use Visualbuilder\FilamentTranscribe\Services\AwsTranscribeClientFactory;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Events\TranscriptUpdated;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Services\AwsTranscribeClientFactory;
 
 class PollTranscriptionJob implements ShouldQueue
 {

--- a/src/Jobs/TranscribeAudioJob.php
+++ b/src/Jobs/TranscribeAudioJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Jobs;
+namespace VisualBuilder\FilamentTranscribe\Jobs;
 
 use Aws\TranscribeService\TranscribeServiceClient;
 use Illuminate\Bus\Queueable;
@@ -9,10 +9,10 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
-use Visualbuilder\FilamentTranscribe\Events\TranscriptUpdated;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
-use Visualbuilder\FilamentTranscribe\Services\AwsTranscribeClientFactory;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Events\TranscriptUpdated;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Services\AwsTranscribeClientFactory;
 
 class TranscribeAudioJob implements ShouldQueue
 {

--- a/src/Models/Transcript.php
+++ b/src/Models/Transcript.php
@@ -1,11 +1,11 @@
 <?php
-namespace Visualbuilder\FilamentTranscribe\Models;
+namespace VisualBuilder\FilamentTranscribe\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
-use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
+use VisualBuilder\FilamentTranscribe\Enums\TranscriptStatus;
 
 class Transcript extends Model implements HasMedia
 {

--- a/src/Services/AwsTranscribeClientFactory.php
+++ b/src/Services/AwsTranscribeClientFactory.php
@@ -1,5 +1,5 @@
 <?php
-namespace Visualbuilder\FilamentTranscribe\Services;
+namespace VisualBuilder\FilamentTranscribe\Services;
 
 use Aws\TranscribeService\TranscribeServiceClient;
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,5 @@
 <?php
 
-use Visualbuilder\FilamentTranscribe\Tests\TestCase;
+use VisualBuilder\FilamentTranscribe\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Visualbuilder\FilamentTranscribe\Tests;
+namespace VisualBuilder\FilamentTranscribe\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Visualbuilder\FilamentTranscribe\FilamentTranscribeServiceProvider;
+use VisualBuilder\FilamentTranscribe\FilamentTranscribeServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Visualbuilder\\FilamentTranscribe\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName) => 'VisualBuilder\\FilamentTranscribe\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
     }
 

--- a/tests/TranscriptResourceTest.php
+++ b/tests/TranscriptResourceTest.php
@@ -5,9 +5,9 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Auth\User;
-use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\AudioPlayer;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
-use Visualbuilder\FilamentTranscribe\Models\Transcript;
+use VisualBuilder\FilamentTranscribe\Filament\Forms\Components\AudioPlayer;
+use VisualBuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
+use VisualBuilder\FilamentTranscribe\Models\Transcript;
 
 it('uses the Transcript model', function () {
     expect(TranscriptResource::getModel())->toBe(Transcript::class);


### PR DESCRIPTION
## Summary
- fix inconsistent capitalization of `VisualBuilder` namespace across codebase
- update composer autoloading config to match `VisualBuilder` namespace
- refresh docs and tests for `VisualBuilder`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689258bc8c1883338ce2755ec1915fef