### PR TITLE
Upgrade to Filament 4 and Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,19 @@
     "require": {
         "php": "^8.2",
         "aws/aws-sdk-php": "^3.339",
-        "filament/filament": "^3.3",
-        "filament/spatie-laravel-media-library-plugin": "^3.3",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
-        "laravel/framework": "^10.0||^11.0||^12.0",
-        "spatie/laravel-package-tools": "^1.16",
-        "visualbuilder/filament-tinyeditor": "dev-main"
+        "filament/filament": "^4.0",
+        "filament/spatie-laravel-media-library-plugin": "^4.0",
+        "illuminate/contracts": "^11.0",
+        "laravel/framework": "^11.0",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "8.*",
+        "nunomaduro/collision": "^8.1.1",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.0 || ^3.0",
         "pestphp/pest-plugin-arch": "^2.0 || ^3.0",
-        "pestphp/pest-plugin-laravel": "^2.4 || ^3.0"
+        "pestphp/pest-plugin-laravel": "^3.0"
     },
     "suggest": {
         "pusher/pusher-php-server": "Recommended if you wish to broadcast events using Pusher."

--- a/config/filament-transcribe.php
+++ b/config/filament-transcribe.php
@@ -1,5 +1,6 @@
 <?php
-use Filament\Pages\SubNavigationPosition;
+
+use Filament\Pages\Enums\SubNavigationPosition;
 
 // config for Visualbuilder/FilamentTranscribe
 return [
@@ -7,86 +8,83 @@ return [
     /**
      * AWS Transcribe Client Credentials
      */
-    'aws'                    => [
+    'aws' => [
         'transcribe' => [
-            'key'                  => env('AWS_ACCESS_KEY_ID'),
-            'secret'               => env('AWS_SECRET_ACCESS_KEY'),
-            'region'               => env('AWS_DEFAULT_REGION', 'eu-west-2'),
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION', 'eu-west-2'),
 
-            'inputDisk'            => 's3',
-            'outputDisk'           => 's3',
-            'showSpeakerLabels'    => true,
+            'inputDisk' => 's3',
+            'outputDisk' => 's3',
+            'showSpeakerLabels' => true,
 
-            'languageCode'         => 'en-GB',
+            'languageCode' => 'en-GB',
 
             /**
              * GB not supported for redaction ATM
              */
             'languageCodeRedacted' => 'en-US',
 
-
             /**
              * Redaction Options, choose from options below or ALL
              */
-            'redactType'           => ['ALL']
-            /**
-             * PII Redaction Types
-             *
-             * ADDRESS
-             * A physical address, such as 100 Main Street, Anytown, USA or Suite #12, Building 123. An address can include a street, building, location, city, state, country, county, zip, precinct, neighborhood, and more.
-             *
-             * ALL
-             * Redact or identify all PII types listed in this table.
-             *
-             * BANK_ACCOUNT_NUMBER
-             * A US bank account number. These are typically between 10 - 12 digits long, but Amazon Transcribe also recognizes bank account numbers when only the last 4 digits are present.
-             *
-             * BANK_ROUTING
-             * A US bank account routing number. These are typically 9 digits long, but Amazon Transcribe also recognizes routing numbers when only the last 4 digits are present.
-             *
-             * CREDIT_DEBIT_CVV
-             * A 3-digit card verification code (CVV) that is present on VISA, MasterCard, and Discover credit and debit cards. In American Express credit or debit cards, it is a 4-digit numeric code.
-             *
-             * CREDIT_DEBIT_EXPIRY
-             * The expiration date for a credit or debit card. This number is usually 4 digits long and formatted as month/year or MM/YY. For example, Amazon Transcribe can recognize expiration dates such as 01/21, 01/2021, and Jan 2021.
-             *
-             * CREDIT_DEBIT_NUMBER
-             * The number for a credit or debit card. These numbers can vary from 13 to 16 digits in length, but Amazon Transcribe also recognizes credit or debit card numbers when only the last 4 digits are present.
-             *
-             * EMAIL
-             * An email address, such as efua.owusu@email.com.
-             *
-             * NAME
-             * An individual's name. This entity type does not include titles, such as Mr., Mrs., Miss, or Dr. Amazon Transcribe does not apply this entity type to names that are part of organizations or addresses. For example, Amazon Transcribe recognizes the John Doe Organization as an organization, and Jane Doe Street as an address.
-             *
-             * PHONE
-             * A phone number. This entity type also includes fax and pager numbers.
-             *
-             * PIN
-             * A 4-digit personal identification number (PIN) that allows someone to access their bank account information.
-             *
-             * SSN
-             * A Social Security Number (SSN) is a 9-digit number that is issued to US citizens, permanent residents, and temporary working residents. Amazon Transcribe also recognizes Social Security Numbers when only the last 4 digits are present.
-             */
-        ]
+            'redactType' => ['ALL'],
+        /**
+         * PII Redaction Types
+         *
+         * ADDRESS
+         * A physical address, such as 100 Main Street, Anytown, USA or Suite #12, Building 123. An address can include a street, building, location, city, state, country, county, zip, precinct, neighborhood, and more.
+         *
+         * ALL
+         * Redact or identify all PII types listed in this table.
+         *
+         * BANK_ACCOUNT_NUMBER
+         * A US bank account number. These are typically between 10 - 12 digits long, but Amazon Transcribe also recognizes bank account numbers when only the last 4 digits are present.
+         *
+         * BANK_ROUTING
+         * A US bank account routing number. These are typically 9 digits long, but Amazon Transcribe also recognizes routing numbers when only the last 4 digits are present.
+         *
+         * CREDIT_DEBIT_CVV
+         * A 3-digit card verification code (CVV) that is present on VISA, MasterCard, and Discover credit and debit cards. In American Express credit or debit cards, it is a 4-digit numeric code.
+         *
+         * CREDIT_DEBIT_EXPIRY
+         * The expiration date for a credit or debit card. This number is usually 4 digits long and formatted as month/year or MM/YY. For example, Amazon Transcribe can recognize expiration dates such as 01/21, 01/2021, and Jan 2021.
+         *
+         * CREDIT_DEBIT_NUMBER
+         * The number for a credit or debit card. These numbers can vary from 13 to 16 digits in length, but Amazon Transcribe also recognizes credit or debit card numbers when only the last 4 digits are present.
+         *
+         * EMAIL
+         * An email address, such as efua.owusu@email.com.
+         *
+         * NAME
+         * An individual's name. This entity type does not include titles, such as Mr., Mrs., Miss, or Dr. Amazon Transcribe does not apply this entity type to names that are part of organizations or addresses. For example, Amazon Transcribe recognizes the John Doe Organization as an organization, and Jane Doe Street as an address.
+         *
+         * PHONE
+         * A phone number. This entity type also includes fax and pager numbers.
+         *
+         * PIN
+         * A 4-digit personal identification number (PIN) that allows someone to access their bank account information.
+         *
+         * SSN
+         * A Social Security Number (SSN) is a 9-digit number that is issued to US citizens, permanent residents, and temporary working residents. Amazon Transcribe also recognizes Social Security Numbers when only the last 4 digits are present.
+         */
+        ],
     ],
 
     /**
      * laravel disk to save audio file - must be an s3 disk for aws
-     *
      */
-    'disk'                   => 's3',
+    'disk' => 's3',
 
     /**
      * Where browser recordings are initially stored
      */
-    'recordings'             => [
-        'disk'      => env('FILAMENT_TRANSCRIBE_RECORDING_DISK', 'local'),
+    'recordings' => [
+        'disk' => env('FILAMENT_TRANSCRIBE_RECORDING_DISK', 'local'),
         'directory' => 'recordings',
     ],
 
     'keep_alive_interval_ms' => 60000,
-
 
     /**
      * |--------------------------------------------------------------------------
@@ -124,47 +122,46 @@ return [
     /**
      * Which files are allowed to be uploaded
      */
-    'allowed_file_types'     => [
-        'audio/mpeg'   => 'mp3',
-        'audio/mp4'    => 'm4a',
-        'audio/x-m4a'  => 'm4a',
+    'allowed_file_types' => [
+        'audio/mpeg' => 'mp3',
+        'audio/mp4' => 'm4a',
+        'audio/x-m4a' => 'm4a',
         'audio/x-aiff' => 'aiff',
-        'audio/flac'   => 'flac',
-        'audio/wav'    => 'wav',
-        'video/mp4'    => 'mp4',
-        'audio/ogg'    => 'ogg',
-        'video/webm'   => 'webm',
+        'audio/flac' => 'flac',
+        'audio/wav' => 'wav',
+        'video/mp4' => 'mp4',
+        'audio/ogg' => 'ogg',
+        'video/webm' => 'webm',
     ],
 
     /**
      * Navigation options for Resource Page
      */
-    'navigation'             => [
-        'enabled'           => true,
+    'navigation' => [
+        'enabled' => true,
         'visible_on_navbar' => true,
-        'icon'              => 'heroicon-o-microphone',
-        'group'             => null,
-        'label'             => 'Transcripts',
-        'url'               => 'transcripts',
-        'cluster'           => null,
-        'sort'              => 1,
-        'subnav_position'   => SubNavigationPosition::Top
+        'icon' => 'heroicon-o-microphone',
+        'group' => null,
+        'label' => 'Transcripts',
+        'url' => 'transcripts',
+        'cluster' => null,
+        'sort' => 1,
+        'subnav_position' => SubNavigationPosition::Top,
     ],
 
-    'transcript_model'    => \Visualbuilder\FilamentTranscribe\Models\Transcript::class,
+    'transcript_model' => \Visualbuilder\FilamentTranscribe\Models\Transcript::class,
     'transcript_resource' => \Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource::class,
 
     /**
      * Which user classes will be available on the transcript owner morph select
      */
-    'user_models'         => [
+    'user_models' => [
         [
-            'model'           => config('auth.providers.users.model'),
+            'model' => config('auth.providers.users.model'),
             'title_attribute' => 'name', // or 'email'
         ],
-        //Add additional user models
+        // Add additional user models
 
     ],
-
 
 ];

--- a/src/Filament/Forms/Components/AudioPlayer.php
+++ b/src/Filament/Forms/Components/AudioPlayer.php
@@ -2,16 +2,14 @@
 
 namespace Visualbuilder\FilamentTranscribe\Filament\Forms\Components;
 
-use Filament\Forms\Components\Component;
-use Filament\Forms\Components\View;
+use Filament\Forms\Components\ViewField;
 
-class AudioPlayer extends Component
+class AudioPlayer extends ViewField
 {
-
     protected string $view = 'filament-transcribe::components.audio_player';
 
-    public static function make(string $name = 'audioPlayer'): static
+    public static function make(?string $name = 'audioPlayer'): static
     {
-        return app(static::class);
+        return parent::make($name);
     }
 }

--- a/src/Filament/Resources/TranscriptResource.php
+++ b/src/Filament/Resources/TranscriptResource.php
@@ -2,22 +2,22 @@
 
 namespace Visualbuilder\FilamentTranscribe\Filament\Resources;
 
-use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Section;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\View;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
-use Filament\Pages\SubNavigationPosition;
+use Filament\Forms\Components\ViewField;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
-use Visualbuilder\FilamentTinyEditor\TinyEditor;
 use Visualbuilder\FilamentTranscribe\Enums\TranscriptStatus;
 use Visualbuilder\FilamentTranscribe\Filament\Actions\StatusBadge;
 use Visualbuilder\FilamentTranscribe\Filament\Fields\AudioUploadField;
@@ -59,8 +59,6 @@ class TranscriptResource extends Resource
 
     /**
      * Note this must be set in the config - appears to be a filament bug -> plugin is not initialised when filament('filament-transcribe') called
-     *
-     * @return string|null
      */
     public static function getCluster(): ?string
     {
@@ -70,133 +68,130 @@ class TranscriptResource extends Resource
     /**
      * Another bug filament('filament-transcribe')->getNavigationSubnavPosition() does not get called
      * Using config value works though
-     *
-     * @return SubNavigationPosition
      */
     public static function getSubNavigationPosition(): SubNavigationPosition
     {
         return config('filament-transcribe.navigation.subnav_position');
     }
 
-
-    public static function form(Form $form): Form
+    public static function form(Schema $schema): Schema
     {
-        return $form
-                ->columns(1)
-                ->schema([
-                        Section::make('Transcript')
-                                ->headerActions([
-                                        StatusBadge::make('status')
-                                ])
-                                ->schema(self::createTranscriptFields() + self::editTranscriptFields($form)),
+        return $schema
+            ->columns(1)
+            ->schema([
+                Section::make('Transcript')
+                    ->headerActions([
+                        StatusBadge::make('status'),
+                    ])
+                    ->schema(self::createTranscriptFields() + self::editTranscriptFields()),
 
-                ]);
+            ]);
     }
 
     public static function createTranscriptFields(): array
     {
         return [
-                AudioUploadField::make(),
-                Toggle::make('redact_pii')
-                        ->default(true)
-                        ->label('Redact Personally Identifiable Information  (Forces en_US instead of en_GB)')
-                        ->hint('Removes names, email, address, bank details, phone numbers '),
+            AudioUploadField::make(),
+            Toggle::make('redact_pii')
+                ->default(true)
+                ->label('Redact Personally Identifiable Information  (Forces en_US instead of en_GB)')
+                ->hint('Removes names, email, address, bank details, phone numbers '),
         ];
     }
 
-    public static function editTranscriptFields($form): array
+    public static function editTranscriptFields(): array
     {
         return [
-                AudioPlayer::make(),
-                Grid::make()
-                        ->columns(2)
-                        ->schema([
-                                OwnerMorphSelectField::make(),
-                                Repeater::make('speaker_names')
-                                        ->label(null)
-                                        ->simple(
-                                                TextInput::make('name')
-                                                        ->label(null)
-                                                        ->required(),
-                                        )
-                                        ->default([
-                                                'Associate',
-                                                'End User',
-                                        ])
-                                        ->minItems(1)
-                                        ->maxItems(8)
-                                        ->columnSpan(1)
-                        ]),
-            
-                Placeholder::make('progress')
-                        ->label(false)
-                        ->hiddenOn('create')
-                        ->content(new HtmlString("<div class='flex items-center justify-center min-h-[100px]'><div class='block-loader'></div><span class='ml-4'>Transcribing in progress</span></div>"))
-                        ->visible(fn($livewire) => $livewire->showProgress ?? false),
+            AudioPlayer::make(),
+            Grid::make()
+                ->columns(2)
+                ->schema([
+                    OwnerMorphSelectField::make(),
+                    Repeater::make('speaker_names')
+                        ->label(null)
+                        ->simple(
+                            TextInput::make('name')
+                                ->label(null)
+                                ->required(),
+                        )
+                        ->default([
+                            'Associate',
+                            'End User',
+                        ])
+                        ->minItems(1)
+                        ->maxItems(8)
+                        ->columnSpan(1),
+                ]),
 
-                TinyEditor::make('transcribed_html')
-                        ->label('Transcription')
-                        ->live()
-                        ->hiddenOn('create')
-                        ->placeholder('This will be automatically filled by a background process.')
-                        ->visible(fn(Get $get) => $get('audio'))
-                        ->nullable(),
+            Placeholder::make('progress')
+                ->label(false)
+                ->hiddenOn('create')
+                ->content(new HtmlString("<div class='flex items-center justify-center min-h-[100px]'><div class='block-loader'></div><span class='ml-4'>Transcribing in progress</span></div>"))
+                ->visible(fn ($livewire) => $livewire->showProgress ?? false),
 
-            //Create echo listener for broadcast event notifying that the transcript is complete
-                View::make('filament-transcribe::components.transcript_echo')
-                        ->hiddenOn('create')
-                        ->viewData(['transcriptId' => $form->getRecord()?->id])
+            RichEditor::make('transcribed_html')
+                ->label('Transcription')
+                ->live()
+                ->hiddenOn('create')
+                ->placeholder('This will be automatically filled by a background process.')
+                ->visible(fn (Get $get) => $get('audio'))
+                ->nullable(),
+
+            // Create echo listener for broadcast event notifying that the transcript is complete
+            ViewField::make('transcript_echo')
+                ->hiddenOn('create')
+                ->view('filament-transcribe::components.transcript_echo')
+                ->viewData(fn ($record): array => ['transcriptId' => $record?->id]),
         ];
     }
-
 
     public static function table(Table $table): Table
     {
         return $table
-                ->defaultSort('id', 'desc')
-                ->columns([
-                        Tables\Columns\TextColumn::make('id')
-                                ->label('ID')
-                                ->sortable()
-                                ->searchable(),
+            ->defaultSort('id', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->sortable()
+                    ->searchable(),
 
-                        TextColumn::make('duration_seconds')
-                                ->label('Duration H:m:s')
-                                ->sortable()
-                                ->formatStateUsing(function ($state) {
-                                    $totalSeconds = $state ?? 0;
-                                    $hours = floor($totalSeconds / 3600);
-                                    $minutes = floor(($totalSeconds % 3600) / 60);
-                                    $seconds = $totalSeconds % 60;
-                                    return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
-                                }),
-                        Tables\Columns\TextColumn::make('transcribed_text')
-                                ->label('Transcript')
-                                ->limit(50)
-                                ->wrap()
-                                ->searchable(),
-                        Tables\Columns\TextColumn::make('status')
-                                ->badge()
-                                ->formatStateUsing(fn($state) => TranscriptStatus::from($state->value)->getLabel())
-                                ->color(fn($state) => TranscriptStatus::from($state->value)->getColor())
-                ])
-                ->actions([
-                        Tables\Actions\EditAction::make(),
-                ])
-                ->bulkActions([
-                        Tables\Actions\BulkActionGroup::make([
-                                Tables\Actions\DeleteBulkAction::make(),
-                        ]),
-                ]);
+                TextColumn::make('duration_seconds')
+                    ->label('Duration H:m:s')
+                    ->sortable()
+                    ->formatStateUsing(function ($state) {
+                        $totalSeconds = $state ?? 0;
+                        $hours = floor($totalSeconds / 3600);
+                        $minutes = floor(($totalSeconds % 3600) / 60);
+                        $seconds = $totalSeconds % 60;
+
+                        return sprintf('%02d:%02d:%02d', $hours, $minutes, $seconds);
+                    }),
+                Tables\Columns\TextColumn::make('transcribed_text')
+                    ->label('Transcript')
+                    ->limit(50)
+                    ->wrap()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->formatStateUsing(fn ($state) => TranscriptStatus::from($state->value)->getLabel())
+                    ->color(fn ($state) => TranscriptStatus::from($state->value)->getColor()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
     }
-
 
     public static function getPages(): array
     {
         return [
-                'index'  => Pages\ListTranscripts::route('/'),
-                'record' => Pages\RecordAudio::route('/record'),
-                'edit'   => Pages\EditTranscript::route('/{record}/edit'),
+            'index' => Pages\ListTranscripts::route('/'),
+            'record' => Pages\RecordAudio::route('/record'),
+            'edit' => Pages\EditTranscript::route('/{record}/edit'),
         ];
     }
 }

--- a/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
+++ b/src/Filament/Resources/TranscriptResource/Pages/RecordAudio.php
@@ -2,28 +2,30 @@
 
 namespace Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource\Pages;
 
+use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Placeholder;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Form;
 use Filament\Resources\Pages\CreateRecord;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Illuminate\Support\Facades\Storage;
-use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Livewire\WithFileUploads;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\RecordingInfo;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\SoundCheck;
+use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 
 class RecordAudio extends CreateRecord
 {
     use WithFileUploads;
+
     protected static string $resource = TranscriptResource::class;
 
-    protected static string $view = 'filament-transcribe::pages.record-audio';
+    protected string $view = 'filament-transcribe::pages.record-audio';
 
     public ?array $data = [];
+
     /**
      * Temporary uploaded audio file.
      */
@@ -44,14 +46,9 @@ class RecordAudio extends CreateRecord
      */
     public bool $showProgress = false;
 
-    public function mount(): void
+    public function form(Schema $schema): Schema
     {
-        $this->form->fill();
-    }
-
-    public function form(Form $form): Form
-    {
-        return $form
+        return $schema
             ->schema([
                 Section::make('Record Session')
                     ->schema([
@@ -60,34 +57,34 @@ class RecordAudio extends CreateRecord
                             ->native()
                             ->options([])
                             ->required()
-                            ->visible(fn($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress),
+                            ->visible(fn ($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress),
                         Toggle::make('redact_pii')
                             ->default(true)
                             ->label('Redact Personally Identifiable Information')
-                            ->visible(fn($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress),
+                            ->visible(fn ($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress),
                         SoundCheck::make(),
                         RecordingInfo::make(),
                         Placeholder::make('progress')
                             ->label(false)
-                            ->content(fn() => view('filament-transcribe::components.upload_progress'))
-                            ->visible(fn($livewire) => $livewire->showProgress),
+                            ->content(fn () => view('filament-transcribe::components.upload_progress'))
+                            ->visible(fn ($livewire) => $livewire->showProgress),
                     ])
                     ->footerActions([
                         Action::make('check_levels')
                             ->label(__('vb-transcribe::audio_recorder.buttons.check_levels'))
-                            ->visible(fn($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress)
+                            ->visible(fn ($livewire) => ! $livewire->recording && ! $livewire->checkingLevels && ! $livewire->showProgress)
                             ->action('startLevelCheck'),
                         Action::make('start_recording')
                             ->icon('heroicon-m-microphone')
                             ->label(__('vb-transcribe::audio_recorder.buttons.start_recording'))
-                            ->visible(fn($livewire) => $livewire->checkingLevels)
+                            ->visible(fn ($livewire) => $livewire->checkingLevels)
                             ->action('startRecording'),
                         Action::make('stop_recording')
                             ->label(__('vb-transcribe::audio_recorder.buttons.stop'))
                             ->icon('fas-circle-stop')
-                            ->visible(fn($livewire) => $livewire->recording)
+                            ->visible(fn ($livewire) => $livewire->recording)
                             ->action('stopRecording'),
-                    ])->footerActionsAlignment(Alignment::Center)
+                    ])->footerActionsAlignment(Alignment::Center),
             ])
             ->statePath('data');
     }
@@ -99,8 +96,8 @@ class RecordAudio extends CreateRecord
         }
 
         $disk = config('filament-transcribe.recordings.disk');
-        $dir  = trim(config('filament-transcribe.recordings.directory'), '/');
-        $name = 'recording-' . now()->format('YmdHis') . '.webm';
+        $dir = trim(config('filament-transcribe.recordings.directory'), '/');
+        $name = 'recording-'.now()->format('YmdHis').'.webm';
         $path = $this->recordingFile->storeAs($dir, $name, $disk);
         $this->recordingFile = null;
         $this->recording = false;
@@ -110,7 +107,6 @@ class RecordAudio extends CreateRecord
         $transcript = $model::create([
             'redact_pii' => $this->data['redact_pii'] ?? true,
         ]);
-
 
         $transcript->addMedia(Storage::disk($disk)->path($path))
             ->usingFileName($name)

--- a/src/FilamentTranscribePlugin.php
+++ b/src/FilamentTranscribePlugin.php
@@ -4,11 +4,10 @@ namespace Visualbuilder\FilamentTranscribe;
 
 use Closure;
 use Filament\Contracts\Plugin;
-use Filament\Pages\SubNavigationPosition;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
-
 
 class FilamentTranscribePlugin implements Plugin
 {
@@ -18,15 +17,20 @@ class FilamentTranscribePlugin implements Plugin
 
     // Navigation properties that can be overridden
     protected ?string $navigationGroup = null;
+
     protected ?string $navigationLabel = null;
+
     protected ?string $navigationIcon = null;
+
     protected ?string $navigationUrl = null;
+
     protected ?int $navigationSort = null;
+
     protected ?bool $navigationVisibleOnNavbar = null;
+
     protected ?string $navigationCluster = null;
+
     protected ?SubNavigationPosition $navigationSubnavPosition = null;
-
-
 
     public static function make(): static
     {
@@ -65,48 +69,56 @@ class FilamentTranscribePlugin implements Plugin
     public function navigationGroup(?string $navigationGroup): static
     {
         $this->navigationGroup = $navigationGroup;
+
         return $this;
     }
 
     public function navigationLabel(string $label): static
     {
         $this->navigationLabel = $label;
+
         return $this;
     }
 
     public function navigationIcon(string $icon): static
     {
         $this->navigationIcon = $icon;
+
         return $this;
     }
 
     public function navigationUrl(string $url): static
     {
         $this->navigationUrl = $url;
+
         return $this;
     }
 
     public function navigationSort(int $sort): static
     {
         $this->navigationSort = $sort;
+
         return $this;
     }
 
     public function navigationVisibleOnNavbar(bool $visible): static
     {
         $this->navigationVisibleOnNavbar = $visible;
+
         return $this;
     }
 
     public function cluster(?string $cluster): static
     {
         $this->cluster = $cluster;
+
         return $this;
     }
 
     public function navigationSubnavPosition(SubNavigationPosition $position): static
     {
         $this->navigationSubnavPosition = $position;
+
         return $this;
     }
 

--- a/tests/TranscriptResourceTest.php
+++ b/tests/TranscriptResourceTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Filament\Pages\SubNavigationPosition;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
-use Illuminate\Support\Facades\Auth;
+use Filament\Forms\Components\Toggle;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Auth;
 use Visualbuilder\FilamentTranscribe\Filament\Forms\Components\AudioPlayer;
 use Visualbuilder\FilamentTranscribe\Filament\Resources\TranscriptResource;
 use Visualbuilder\FilamentTranscribe\Models\Transcript;
@@ -22,20 +22,14 @@ it('provides create transcript fields', function () {
 });
 
 it('provides edit transcript fields', function () {
-    $user = new User();
+    $user = new User;
     $user->id = 1;
     $user->email = 'test@example.com';
     $user->name = 'Test User';
     $user->exists = true;
     Auth::login($user);
 
-    $form = Mockery::mock(\Filament\Forms\Form::class);
-    $record = new Transcript();
-    $record->id = 1;
-    $record->exists = true;
-    $form->shouldReceive('getRecord')->andReturn($record);
-
-    $fields = TranscriptResource::editTranscriptFields($form);
+    $fields = TranscriptResource::editTranscriptFields();
 
     expect($fields)->toHaveCount(5)
         ->and($fields[0])->toBeInstanceOf(AudioPlayer::class);


### PR DESCRIPTION
## Summary
- Require Filament 4 and Laravel 11
- Migrate navigation and forms to Filament 4 namespaces and schema API
- Replace TinyEditor with built-in RichEditor and update custom components

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a45d9035208333beff3b84c5e5f8b0