### PR TITLE
chore: allow laravel 13 (testbench ^11) and cover it in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
         "aws/aws-sdk-php": "^3.339",
         "filament/filament": "^5.0",
         "filament/spatie-laravel-media-library-plugin": "^5.0",
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-arch": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0"


### PR DESCRIPTION
Part of the Laravel 13 readiness sweep across visualbuilder packages (neurobox NB-2860 groundwork).

Constraint widening only — no behaviour changes. Suite verified locally on laravel/framework **v13.19.0**: 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)